### PR TITLE
Configure targets should be relative paths

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -34,7 +34,7 @@ for name in callauto.c client/*.c *.c client/agents/*.c \
 
     objfile=objectfiles/$(basename $name .c).o
     ev="$ev $objfile"
-    output "$objfile: $SRC/$name"
+    output "$objfile: $name"
     output "	\$(CC) \$(CC_FLAGS) $additional -c -o $objfile $SRC/$name"
 done
 popd


### PR DESCRIPTION
I think configure should make the Makefile targets relative rather than absolute paths (i.e., excluding `$SRC`, as I have done in this PR).  I was getting "no target found" errors.
