### PR TITLE
Allow option to install to SD Card

### DIFF
--- a/android/project/AndroidManifest.xml
+++ b/android/project/AndroidManifest.xml
@@ -2,7 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
       package="pl.org.zielinscy.freeciv.debug"
       android:versionCode="1"
-      android:versionName="1.0">
+      android:versionName="1.0"
+      android:installLocation="auto">
     <uses-sdk android:minSdkVersion="10" />
     <uses-feature android:glEsVersion="0x00020000" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />


### PR DESCRIPTION
Edit AndroidManifest.xml to add android:installLocation="auto". This allows the user to choose to install part of the app to their SD Card to help save install space. See also http://code.tutsplus.com/tutorials/quick-tip-enabling-the-android-move-to-sd-card-feature--mobile-862
